### PR TITLE
Added support for native packaging drop-in resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,31 @@ For creating so-called "native bundles", that is, self-contained applications wh
 ```scala
 JFX.nativeBundles := bundleType	// where bundleType is a String
 ```
-A typical value for the bundle type is `"image"`.  See the [JavaFX documentation](http://docs.oracle.com/javafx/2/deployment/self-contained-packaging.htm) for possible values and further information.
+A typical value for `bundleType` is one of:
+
+* `all` - create all native bundles available on build platform (e.g. `msi` and `exe` on Windows, `dmg` on MacOS X, etc.)
+* `deb` - Debian installer file (Linux only)
+* `dmg` - MacOS X disk image (MacOS X only)
+* `exe` - Windows stand-alone installer (Windows only)
+* `image` - `.jar`-only distribution
+* `msi` - Windows "installer database" file (Windows only)
+* `none` - Don't make native bundle (default)
+* `rpm` - Redhat Package Manager file (Linux only)
+
+
+See the [JavaFX packaging documentation](http://docs.oracle.com/javafx/2/deployment/self-contained-packaging.htm) for possible values and further information.
+
+#### Drop-in Resources
+
+As described in the [Native Packaging Cookbook](https://blogs.oracle.com/talkingjavadeployment/entry/native_packaging_cookbook_using_drop), the native installers generated for each platform may be customized with files copied from the default installer templates (as reported when `verbose="true"` is passed to the `ant deploy` task), and placed in the classpath for the `ClassLoader` associated with `ant-javafx.jar`. This classpath should contain a folder called `package`, where the `deploy` task looks for files with project- and platform-specific files. See the Oracle for specifics, but the base structure is `package/{macosx,windows,linux}/[drop-in-resources]`.
+
+The `JFX.pkgResourcesDir` setting is provided for adding a path to this classpath. For example, if a custom `Info.plist` file for MacOS X is defined in `src/main/resourcespackage/macosx/Info.plist`, the following setting would make it visible to the `deploy` task:
+
+```scala
+JFX.pkgResourcesDir := Some(baseDirectory.value + "/src/main/resources")
+```
+
+The Oracle-provided `ant-javafx.jar` is not very flexible with regard to paths to drop-in resources, so any encountered problems are likely to be associated with mis-named or mis-located files. To debug the packaging process, set `JFX.verbose := true` in your `build.sbt` file, run `sbt deploy` at least once, and then run `ant` against the generated `target/scala-x.yz/build.xml` file (i.e. `build.xml` in `crossTarget`). Running `ant` with the `deploy` task in verbose mode directly simplifies the debugging process when your drop-in resources aren't being picked up by `ant-javafx.jar`.
 
 #### Using the correct Java version
 


### PR DESCRIPTION
This change set introduces the new setting `JFX.pkgResourcesDir` which allows the specification of a directory where the ant-javafx.jar `deploy` task will look for native packaging drop-in resources.

If this change set is acceptable, I can update the examples with one with customized drop-in resources, if interested.  
