### PR TITLE
Fixed bug where copyright and description metadata values were swapped

### DIFF
--- a/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
+++ b/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
@@ -292,7 +292,7 @@ object JavaFXPlugin extends Plugin {
     JFX.description := "",
     JFX.copyright := "",
     JFX.license := "",
-    JFX.info <<= (JFX.vendor, JFX.title, JFX.category, JFX.description, JFX.copyright, JFX.license) apply Info.apply,
+    JFX.info <<= (JFX.vendor, JFX.title, JFX.category, JFX.copyright, JFX.description, JFX.license) apply Info.apply,
     JFX.keyStore := None,
     JFX.storePass := None,
     JFX.alias := None,


### PR DESCRIPTION
Copyright string and description string were swapped in transfer from `Info` case class and key settings.
