### PR TITLE
Package preparation hook

### DIFF
--- a/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
+++ b/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
@@ -333,7 +333,7 @@ object JavaFXPlugin extends Plugin {
     JFX.description := "",
     JFX.copyright := "",
     JFX.license := "",
-    JFX.info <<= (JFX.vendor, JFX.title, JFX.appVersion, JFX.category, JFX.description, JFX.copyright, JFX.license) apply Info.apply,
+    JFX.info <<= (JFX.vendor, JFX.title, JFX.appVersion, JFX.category, JFX.copyright, JFX.description, JFX.license) apply Info.apply,
     JFX.keyStore := None,
     JFX.storePass := None,
     JFX.alias := None,


### PR DESCRIPTION
I have some application specific customization I need to apply to the JavaFX packaging configuration that's outside the scope of the plugin (one such tweak is to work around a JavaFX packager bug in the WiX-based installer). 

I'd like to be able to apply my customizations within the processing of the `sbt-javafx` workflow so I don't have to build things twice (which can take a while on Windows). 

This pull request proposes _one_ way of tweaking the plugin to expose the "pre-package" vs. "package" stages. It does this by separating the deployment artifact copying and `build.xml` generation into a separate task, upon which the Ant invocation task (`package-javafx`) depends upon.

Because the approach implemented exposes a new task, thereby exposing a new API, I suggest it be given more critical thought than normal. While I've read the "Plugin Best Practices" section of the SBT docs, I've not developed a plugin before and don't know if what I'm proposing is ultimately a good idea. It suffices for my immediate needs (I can now redefine the updated `package-javafx` task in my `build.sbt` file without reimplementing hard stuff), and I can use my fork until a final solution is deployed.

Generally speaking I think breaking the process up is a good idea, giving users additional flexibility they will likely need; it's the selection of an approach for accomplishing it that I want to flag for particular critique.
