### PR TITLE
Internal dependencies fix

### DIFF
--- a/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
+++ b/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
@@ -236,9 +236,10 @@ object JavaFXPlugin extends Plugin {
               <fx:platform refid="platform"/>
               <fx:fileset dir={ classDir.getAbsolutePath }/>
               {
-                for (classpath <- internalDependencyClasspath) yield {
-                  <fx:fileset dir={classpath.data.getAbsolutePath}/>
-                }
+                for (
+                  classpath <- internalDependencyClasspath
+                  if classpath.data.isDirectory
+                ) yield { <fx:fileset dir={classpath.data.getAbsolutePath}/> }
               }
               <fx:resources>
                 { if (libJars.nonEmpty) <fx:fileset dir={ crossTarget.getAbsolutePath } includes="lib/*.jar"/> }


### PR DESCRIPTION
Hi,

Here is a fix I've come up with for issue #12 . I just add another fileset to the ant task for each directory in the  `internalDependencyClasspath` SBT key, so the compiled classes from the sub-projects get packaged together with the classes from the main project. External dependencies are not affected.

I have tested it in a small project with a few sub-projects, not all of them in the internal dependencies, and I haven't noticed anything weird. I may always have missed something of course.
