### PR TITLE
manifest additions for javafx jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+
+.idea

--- a/sbt-javafx.sbt
+++ b/sbt-javafx.sbt
@@ -1,8 +1,8 @@
-name := "sbt-javafx"
+name := "sbt-javafx-modified"
 
 organization := "no.vedaadata"
 
-version := "0.6.2-SNAPSHOT"
+version := "0.6.2"
 
 scalaVersion := "2.10.2"
 
@@ -16,13 +16,15 @@ libraryDependencies += "org.apache.ant" % "ant" % "1.8.2"
 
 publishMavenStyle := true
 
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+publishTo := {
+  val artifactory = "http://bill.part.net:8081/artifactory/"
+  if (version.value.trim.endsWith("SNAPSHOT"))
+    Some("snapshots" at artifactory + "libs-snapshot-local-nonunique")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases"  at artifactory + "libs-release-local")
 }
+
+credentials += Credentials(Path.userHome / ".sbt" / "credentials")
 
 publishArtifact in Test := false
 

--- a/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
+++ b/src/main/scala/no/vedaadata/sbtjavafx/JavaFXPlugin.scala
@@ -247,7 +247,7 @@ object JavaFXPlugin extends Plugin {
               <fx:platform refid="platform"/>
               <fx:fileset dir={ classDir.getAbsolutePath }/>
               <fx:resources>
-                { if (libJars.nonEmpty) <fx:fileset dir={ crossTarget.getAbsolutePath } includes="lib/*.jar"/> }
+                { if (libJars.nonEmpty) <fx:fileset dir={ (crossTarget / "lib").getAbsolutePath } includes="*.jar"/> }
               </fx:resources>
                 { if (manifestAttributeXmls.nonEmpty) <manifest>{manifestAttributeXmls}</manifest> }
             </fx:jar>


### PR DESCRIPTION
Great plugin, it saved me a ton of work. 

One thing I needed that it did not do was to be able to add custom manifest entries to the jar created by the plugin.  I modified your plugin to include a mechanism to pass manifest entries down into the xml generated for the javafx ant task.  I used the same key that sbt uses to modify the manifest for the standard packaged jar just scoped to your task.  I figured it may be useful to someone else so your more than welcome to integrate the change into your plugin if you think it fits.

Thanks,
Spencer
